### PR TITLE
use an sprintf implementation which supports JSON (%j)

### DIFF
--- a/lib/format-throw.js
+++ b/lib/format-throw.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var format = require('format');
+var format = require('sprintf-js').sprintf;
 var slice = Array.prototype.slice;
 
 var thr = module.exports = function () {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "mocha": "~2.2.4"
   },
   "dependencies": {
-    "format": "~0.2.1"
+    "sprintf-js": "^1.0.3"
   }
 }

--- a/test/lib.spec.js
+++ b/test/lib.spec.js
@@ -7,13 +7,13 @@ describe('thr()', function () {
   it('should throw an error with a custom constructor and a formatted message', function () {
     var err;
     try {
-      thr(TypeError, '%s is not %s', 'foo', 'bar');
+      thr(TypeError, '%j is not %s', 'foo', 'bar');
     } catch (e) {
       err = e;
     }
 
     expect(err).to.be.an.instanceOf(TypeError);
-    expect(err.message).to.equal('foo is not bar');
+    expect(err.message).to.equal('"foo" is not bar');
   });
 
   it('should throw a default Error when called without a specific constructor', function () {


### PR DESCRIPTION
[format](https://github.com/samsonjs/format) doesn't support JSON (`%j`). [sprintf-js](https://github.com/alexei/sprintf.js) does and also has some other useful features e.g. argument swapping and named arguments.
